### PR TITLE
Fix typo in strides slide

### DIFF
--- a/slides/04_conv_nets/index.html
+++ b/slides/04_conv_nets/index.html
@@ -327,7 +327,7 @@ $$
 ## Strides
 
 - Strides: increment step size for the convolution operator
-- Reduces the size of the ouput map
+- Reduces the size of the output map
 
 .center[
           <img src="images/no_padding_strides.gif" style="width: 260px;" />


### PR DESCRIPTION
This PR fixes a small typo in the strides slide of the conv net section.